### PR TITLE
Switch webhook to GET

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,24 +46,20 @@ This will create all required tables in the Postgres database.
 ### Obtaining an API token via Chatwoot
 
 Chatwoot can call the `/auth/webhook` endpoint when an agent signs in. The
-endpoint expects the following JSON payload:
+endpoint now expects the required fields as query parameters:
 
-```json
-{
-  "account_id": 1,
-  "user_id": 10,
-  "user_email": "agent@example.com",
-  "user_name": "Agent Smith"
-}
+```text
+account_id
+user_id
+user_email
+user_name
 ```
 
 The response contains a token that should be stored as a Chatwoot attribute so it
 can be used for subsequent API calls:
 
 ```bash
-curl -X POST http://localhost:5000/auth/webhook \
-     -H 'Content-Type: application/json' \
-     -d '{"account_id":1,"user_id":10,"user_email":"agent@example.com","user_name":"Agent Smith"}'
+curl "http://localhost:5000/auth/webhook?account_id=1&user_id=10&user_email=agent@example.com&user_name=Agent%20Smith"
 ```
 
 Response:

--- a/app/auth/webhook.py
+++ b/app/auth/webhook.py
@@ -6,11 +6,11 @@ from ..models import Account, User, ApiKey
 from . import auth_bp
 
 
-@auth_bp.route('/auth/webhook', methods=['POST'])
+@auth_bp.route('/auth/webhook', methods=['GET'])
 def auth_webhook():
-    data = request.get_json(silent=True)
-    if not data:
-        data = request.form.to_dict() if request.form else {}
+    # When Chatwoot triggers this webhook it now sends the data as query
+    # parameters in a GET request.  Parse the arguments accordingly.
+    data = request.args.to_dict()
     required_fields = ['account_id', 'user_id', 'user_email', 'user_name']
     missing = [field for field in required_fields if field not in data]
     if missing:

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -8,11 +8,8 @@ function setupLogin() {
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
     const data = Object.fromEntries(new FormData(form));
-    const res = await fetch('/auth/webhook', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data)
-    });
+    const query = new URLSearchParams(data).toString();
+    const res = await fetch(`/auth/webhook?${query}`, { method: 'GET' });
     if (res.ok) {
       const json = await res.json();
       localStorage.setItem('apiToken', json.token);

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -27,7 +27,7 @@ def get_token(client):
         'user_email': 'test@example.com',
         'user_name': 'Tester'
     }
-    response = client.post('/auth/webhook', json=payload)
+    response = client.get('/auth/webhook', query_string=payload)
     assert response.status_code == 200
     token = response.get_json()['token']
     # Promote user to supervisor
@@ -43,7 +43,7 @@ def test_auth_webhook_creates_user(client):
         'user_email': 'new@example.com',
         'user_name': 'New User'
     }
-    response = client.post('/auth/webhook', json=payload)
+    response = client.get('/auth/webhook', query_string=payload)
     assert response.status_code == 200
     data = response.get_json()
     assert 'token' in data


### PR DESCRIPTION
## Summary
- change `/auth/webhook` to use GET parameters
- update frontend login to send GET request
- document new webhook usage in README
- adjust tests for GET behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849b1500870832db5ddc7c6d43adee4